### PR TITLE
Typo README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,5 +74,5 @@ systemctl --user enable figma-fonthelper-updater.service
 
 In terminal:
 ```bash
-~/local/share/figma-fonthelper/fonthelper -v
+~/.local/share/figma-fonthelper/fonthelper -v
 ```


### PR DESCRIPTION
Corrected a minor typo in the directory name, from "local" to ".local" (tested the command and it worked perfectly in my machine, after this correction).