### PR TITLE
Fix: envsubst service file on updater script

### DIFF
--- a/res/updater.sh
+++ b/res/updater.sh
@@ -43,8 +43,8 @@ install() {
   popd
 
   pushd $CONFIG_DIR/systemd/user
-  tar xJf /tmp/fonthelper.tar.xz ./figma-fonthelper.service
-  tar xJf /tmp/fonthelper.tar.xz ./figma-fonthelper-updater.service
+  tar xJOf /tmp/fonthelper.tar.xz ./figma-fonthelper.service | XDG_CONFIG_HOME=$DATA_DIR envsubst > figma-fonthelper.service
+  tar xJOf /tmp/fonthelper.tar.xz ./figma-fonthelper-updater.service | XDG_CONFIG_HOME=$DATA_DIR envsubst > figma-fonthelper-updater.service
 
   chmod 644 figma-fonthelper.service
   chmod 644 figma-fonthelper-updater.service


### PR DESCRIPTION
Font helper service is presenting the following error:
```
● figma-fonthelper.service - Font Helper for Figma
     Loaded: bad-setting (Reason: Unit figma-fonthelper.service has a bad unit file setting.)
     Active: active (running) since Wed 2023-07-26 14:07:36 PST; 6min ago
   Main PID: 7301 (fonthelper)
        CPU: 1.495s
     CGroup: /user.slice/user-1000.slice/user@1000.service/app.slice/figma-fonthelper.service
             └─7301 /home/datsudo/.local/share/figma-fonthelper/fonthelper

Jul 26 14:07:41 eos systemd[1233]: /home/datsudo/.config/systemd/user/figma-fonthelper.service:7: Neither a valid executable name nor an absolute path: ${XDG_CONFIG_HOME}/figma-fonthelper/fonthelper
Jul 26 14:07:41 eos systemd[1233]: figma-fonthelper.service: Unit configuration has fatal error, unit will not be started.
```

This happens because the updater script is not setting the `XDG_CONFIG_HOME` as the installer script is.

Related to issue https://github.com/Figma-Linux/figma-linux-font-helper/issues/38