### PR TITLE
Change default listening port to reflect changes to Figma

### DIFF
--- a/res/install.sh
+++ b/res/install.sh
@@ -33,7 +33,7 @@ install() {
   cat > $APP_CONFIG_DIR/settings.json << EOF
 {
   "host": "127.0.0.1",
-  "port": "18412",
+  "port": "44950",
   "app": {
     "fontDirs": [
       "/usr/share/fonts",


### PR DESCRIPTION
Been using the font helper for a while with no issues, until recently and I think its down to some changes that Figma have made.

From a little investigation, they seem to have stopped trying to fetch local fonts if Figma is loaded from an unsupported OS and they have also changed the port they used to get local fonts.

When I spoofed my UA to `Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/122.0` Figma started trying to get local fonts, however from a different port to what the font helper is listening on. Specifically port `44950` hence this change.

Just to be clear, I use Firefox Developer Edition and therefore I didn't send any client hints HTTP headers. See https://developer.mozilla.org/en-US/docs/Web/API/User-Agent_Client_Hints_API

I tested on Chrome while spoofing the UA and that didn't work, presumably because client hints are enabled on Chrome, but even after disabling Client hints with an extension it still doesn't work on Chrome, so I'm not sure what's going on there.